### PR TITLE
Do not use markup for logging errors as this will give problems when …

### DIFF
--- a/src/appollo/helpers.py
+++ b/src/appollo/helpers.py
@@ -21,7 +21,7 @@ def print_validation_error(console, response_dict):
     """ Pretty print helper for validation errors in the console"""
     error = response_dict.pop('non_field_errors', None)
     if error is not None:
-        console.print(f"Error: {error}")
+        console.print(f"Error: {error}", markup=False)
     for field, errors in response_dict.items():
         if errors is str:
             console.print(f"Error: for {field} - {list(errors)}")


### PR DESCRIPTION
…square brackets are present in the error message.


Recently when I try building an iOs app I receieve the following error:
```
Error: App Store Connect error 403 Forbidden [/v1/devices?limit=200]
```

However, when appollo tries to display the error in the cli, the `console.print()` call tries to apply formatting, but it can't handle the square brackets in the message. The result is the following error:


```
Traceback (most recent call last):
  File "c:\users\simon\appdata\local\programs\python\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\simon\appdata\local\programs\python\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\Simon\AppData\Local\Programs\Python\Python39\Scripts\appollo.exe\__main__.py", line 7, in <module>
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\appollo\helpers.py", line 57, in run
    return ctx.invoke(f, *args, **kwargs)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\click\core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\appollo\commands\apple.py", line 386, in refresh_devices
    devices = api.get(f"/developer-accounts/{key}/refresh-devices/")
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\appollo\api.py", line 85, in get
    return _request("get", route, params=params, authorization=authorization, auth_data=auth_data, json_decode=json_decode)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\appollo\api.py", line 59, in _request
    print_validation_error(console, error)
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\appollo\helpers.py", line 24, in print_validation_error
    console.print(f"Error: {error}")
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\rich\console.py", line 1590, in print
    renderables = self._collect_renderables(
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\rich\console.py", line 1454, in _collect_renderables
    self.render_str(
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\rich\console.py", line 1346, in render_str
    rich_text = render_markup(
  File "c:\users\simon\appdata\local\programs\python\python39\lib\site-packages\rich\markup.py", line 159, in render
    raise MarkupError(
rich.errors.MarkupError: closing tag '[/v1/devices?limit=200]' at position 45 doesn't match any open tag
```

By turning off the formatting for the `console.print()` call, the error message is displayed properly.